### PR TITLE
tests(reservations): cancel my confirmed reservation promotes waitlist and broadcasts

### DIFF
--- a/backend/reservations/tests/test_reservation_endpoints.py
+++ b/backend/reservations/tests/test_reservation_endpoints.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from users.models.user import CustomUser
 from events.models import Event
 from reservations.models import Reservation
+from reservations.services.waitlist_service import promote_from_waitlist_fill
 
 
 @pytest.mark.django_db
@@ -257,3 +258,55 @@ def test_checkin_forbidden_for_non_organizer():
     
 
     assert res.checked_in is False 
+
+
+
+@pytest.mark.django_db
+def test_cancel_my_confirmed_reservation_promotes_waitlist_and_broadcasts():
+
+    organizer = CustomUser.objects.create(email="organizer@example.com", password="pass")
+
+    u1 = CustomUser.objects.create(email="u1@example.com", password="pass")
+    u2 = CustomUser.objects.create(email="u2@example.com", password="pass")
+
+    now = timezone.now()
+
+    event = Event.objects.create(
+        title= "Test",
+        location= "Online",
+        start_time= now + timedelta(days=1),
+        end_time= now + timedelta(days=1, hours=2),
+        organizer= organizer,
+        status= "published",
+        seats_limit= 1
+    )
+
+
+    client = APIClient()
+
+    client.force_authenticate(user=u1)
+
+    res = Reservation.objects.create(event=event, user=u1, status="confirmed")
+    
+    Reservation.objects.create(event=event, user=u2, status="pending")
+
+
+    with ( 
+        patch("reservations.views.cancel_my_reservation.promote_from_waitlist_fill") as promote_mock,
+        patch("reservations.views.cancel_my_reservation.broadcast_event_metrics") as broadcast_mock
+        ):
+
+        resp = client.delete(f"/api/reservations/{res.id}/")
+
+        
+    assert resp.status_code == 200
+
+    assert not Reservation.objects.filter(id=res.id).exists()
+
+    assert promote_mock.call_count == 1
+    assert broadcast_mock.call_count == 1
+
+
+
+
+    


### PR DESCRIPTION
Adds a test for CancelMyReservation:
- confirmed → promotes from waitlist (patched)
- always broadcasts metrics

Run:
  cd backend && pytest -q reservations/tests/test_reservation_endpoints.py::test_cancel_my_confirmed_reservation_promotes_waitlist_and_broadcasts
