### PR TITLE
tests(reservations): cancel pending deletion → no promote, broadcastsonce (200)

### DIFF
--- a/backend/reservations/tests/views/test_cancel_my_reservation.py
+++ b/backend/reservations/tests/views/test_cancel_my_reservation.py
@@ -11,10 +11,10 @@ from reservations.models import Reservation
 @pytest.mark.django_db
 def test_cancel_my_confirmed_reservation_promotes_waitlist_and_broadcasts():
 
-    organizer = CustomUser.objects.create(email="organizer@example.com", password="pass")
+    organizer = CustomUser.objects.create_user(email="organizer@example.com", password="pass")
 
-    u1 = CustomUser.objects.create(email="u1@example.com", password="pass")
-    u2 = CustomUser.objects.create(email="u2@example.com", password="pass")
+    u1 = CustomUser.objects.create_user(email="u1@example.com", password="pass")
+    u2 = CustomUser.objects.create_user(email="u2@example.com", password="pass")
 
     now = timezone.now()
 
@@ -53,3 +53,43 @@ def test_cancel_my_confirmed_reservation_promotes_waitlist_and_broadcasts():
     assert promote_mock.call_count == 1
     assert broadcast_mock.call_count == 1
 
+
+@pytest.mark.django_db
+def test_cancel_pending_reservation_does_not_promote_but_broadcasts():
+
+    organizer = CustomUser.objects.create_user(email="organizer@example.com", password="pass")
+
+    u1 = CustomUser.objects.create_user(email="u1@example.com", password="pass")
+
+    now = timezone.now()
+
+    event = Event.objects.create(
+        title= "Test",
+        location= "Online",
+        start_time= now + timedelta(days=1),
+        end_time= now + timedelta(days=1, hours=2),
+        organizer= organizer,
+        status= "published",
+        seats_limit= 1
+    )
+
+    client = APIClient()
+
+    client.force_authenticate(user=u1)
+
+    res = Reservation.objects.create(event=event, user=u1, status="pending")
+
+    with ( 
+        patch("reservations.views.cancel_my_reservation.promote_from_waitlist_fill") as promote_mock,
+        patch("reservations.views.cancel_my_reservation.broadcast_event_metrics") as broadcast_mock
+        ):
+
+        resp = client.delete(f"/api/reservations/{res.id}/")
+
+    
+    assert promote_mock.call_count == 0
+    assert broadcast_mock.call_count == 1
+
+    assert not Reservation.objects.filter(id=res.id).exists()
+
+    assert resp.status_code == 200


### PR DESCRIPTION
What: Add test for canceling a pending reservation.
Verifies: Row is deleted (DB), no waitlist promotion (promote_from_waitlist_fill = 0×), one metrics broadcast (broadcast_event_metrics = 1×), returns HTTP 200.
Why: Protects CancelMyReservation logic (promotion should happen only when a confirmed reservation is canceled).
How to run:
pytest -q backend/reservations/tests/views/test_cancel_my_reservation.py::test_cancel_pending_reservation_does_not_promote_but_broadcasts