### PR TITLE
tests(events): publish invalid dates -> 400 and keep status=draft

### DIFF
--- a/backend/events/tests/views/test_publish_event.py
+++ b/backend/events/tests/views/test_publish_event.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from django.utils import timezone
+from datetime import timedelta
+from users.models import CustomUser
+from events.models import Event
+from reservations.models import Reservation
+
+
+@pytest.mark.django_db
+def test_publish_event_invalid_dates_returns_400():
+
+    organizer = CustomUser.objects.create_user(email="org@example.com", password="pass")
+
+
+    now = timezone.now() 
+    
+    event = Event.objects.create(
+        title= "Test",
+        location= "Online",
+        start_time= now + timedelta(days=1),
+        end_time= now + timedelta(hours=2),
+        seats_limit= 2,
+        status= "draft",
+        organizer= organizer
+    )
+
+
+    client= APIClient()
+
+    client.force_authenticate(user=organizer)
+
+    resp = client.post(f"/api/events/organizer/{event.id}/publish/")
+
+    assert resp.status_code == 400
+    
+    event.refresh_from_db()
+    
+    assert event.status == "draft"
+
+


### PR DESCRIPTION
PR title: tests(events): publish with invalid dates returns 400

What: Add test for PublishEventView when end_time <= start_time.
Verifies: POST /api/events/organizer/<id>/publish/ → 400 and event stays draft (no status change).
Why: Guard against regressions; publishing must reject invalid date ranges.
How to run:
pytest -q events/tests/views/test_publish_event.py::test_publish_event_invalid_dates_returns_400