### PR TITLE
tests(events): add WebSocket metrics tests (connect + broadcast)

### DIFF
--- a/backend/events/tests/test_consumer_metrics.py
+++ b/backend/events/tests/test_consumer_metrics.py
@@ -1,0 +1,92 @@
+import pytest
+from django.utils import timezone
+from datetime import datetime, timedelta
+from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
+
+from channels.layers import get_channel_layer
+
+
+from channels.testing import WebsocketCommunicator
+from config.asgi import application
+
+from users.models import CustomUser
+from events.models import Event
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_ws_connects_ok():
+
+    organizer = await database_sync_to_async(CustomUser.objects.create_user)(
+    email="org@example.com", password="pass"
+    )
+
+    
+    now = timezone.now() 
+    
+    event = await database_sync_to_async(Event.objects.create)(
+        title="WS test",
+        location="Online",
+        start_time=now + timedelta(days=1),
+        end_time=now + timedelta(days=1, hours=2),
+        seats_limit=10,
+        status="published",
+        organizer=organizer,
+    )
+
+
+    communicator = WebsocketCommunicator(application, f"/ws/events/{event.id}/")
+
+    connected, _ = await communicator.connect()
+
+    assert connected is True
+     
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_ws_metrics_broadcasts_json():
+    
+    organizer = await sync_to_async(CustomUser.objects.create_user)(
+    email="org@example.com", password="pass"
+)
+
+    now = timezone.now()
+    event = await sync_to_async(Event.objects.create)(
+        title="WS test",
+        location="Online",
+        start_time=now + timedelta(days=1),
+        end_time=now + timedelta(days=1, hours=2),
+        seats_limit=10,
+        status="published",
+        organizer=organizer,
+    )
+
+    communicator = WebsocketCommunicator(application, f"/ws/events/{event.id}/")
+    connected, _ = await communicator.connect()
+    assert connected is True
+
+    channel_layer = get_channel_layer()
+    payload = {
+        "type": "metrics",
+        "event_id": event.id,
+        "confirmed_count": 1,
+        "pending_count": 2,
+        "checked_in_count": 0,
+        "spots_left": 5,
+    }
+
+    # Act – wyślij do grupy, którą consumer subskrybuje po connect()
+    await channel_layer.group_send(
+        f"event_{event.id}",
+        {"type": "event.metrics", "payload": payload},
+    )
+
+    data = await communicator.receive_json_from(timeout=2)
+
+    # Assert
+    assert data == payload
+
+    await communicator.disconnect()


### PR DESCRIPTION
tests(events): add WebSocket metrics tests

Added async tests for EventConsumer:
- Client can connect to /ws/events/<id>/
- Metrics broadcast via group_send is delivered as JSON

How to run:
pytest events/tests/test_consumer_metrics.py -v
