### PR TITLE
tests(events): forbid publishing event by non-organizer (403)

### DIFF
--- a/backend/events/tests/views/test_publish_permission.py
+++ b/backend/events/tests/views/test_publish_permission.py
@@ -1,0 +1,41 @@
+import pytest
+from django.utils import timezone
+from datetime import datetime, timedelta
+from rest_framework.test import APIClient
+
+from users.models import CustomUser
+from events.models import Event
+
+
+@pytest.mark.django_db
+def test_publish_event_forbidden_for_non_organizer_returns_403():
+
+    organizer = CustomUser.objects.create_user(email="org@example.com", password="pass")
+
+    u1 = CustomUser.objects.create_user(email="u1@example.com", password="pass")
+
+    now = timezone.now() 
+    
+    event = Event.objects.create(
+        title= "Test",
+        location= "Online",
+        start_time= now + timedelta(days=1),
+        end_time= now + timedelta(hours=2),
+        seats_limit= 2,
+        status= "draft",
+        organizer= organizer
+    )
+
+
+    client = APIClient()
+
+    client.force_authenticate(user=u1)
+
+
+    resp = client.post(f"/api/events/organizer/{event.id}/publish/")
+
+
+    assert resp.status_code == 403
+    event.refresh_from_db()
+
+    assert event.status == "draft"


### PR DESCRIPTION
tests(events): forbid publishing event by non-organizer (403)

Covers permission on publish endpoint:
- Non-organizer POST /api/events/organizer/<id>/publish/ -> 403
- Event status remains 'draft'

How to run:
pytest events/tests/views/test_publish_permission.py -v
