### PR TITLE
tests(reservations): add idempotent cancel reservation test (second call returns 404)

### DIFF
--- a/backend/reservations/tests/views/test_cancel_reservation_idempotent.py
+++ b/backend/reservations/tests/views/test_cancel_reservation_idempotent.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from django.utils import timezone
+from datetime import timedelta
+
+from users.models import CustomUser
+from events.models import Event
+from reservations.models import Reservation
+
+
+@pytest.mark.django_db
+def test_cancel_reservation_twice_second_call_404():
+
+    organizer = CustomUser.objects.create_user(email="org@example.com", password="pass")
+
+    u1 = CustomUser.objects.create_user(email="u1@example.com", password="pass")
+    
+
+    now = timezone.now() 
+    
+    event = Event.objects.create(
+        title= "Test",
+        location= "Online",
+        start_time= now + timedelta(days=1),
+        end_time= now + timedelta(days=2, hours=2),
+        seats_limit= 2,
+        status= "published",
+        organizer= organizer
+    )
+
+    client = APIClient()
+
+    client.force_authenticate(user=u1)
+
+
+    res = Reservation.objects.create(event=event, user=u1, status="confirmed")
+
+    resp1 = client.delete(f"/api/reservations/{res.id}/")
+
+    resp2 = client.delete(f"/api/reservations/{res.id}/")
+
+
+    assert resp1.status_code == 200
+
+    assert not Reservation.objects.filter(id=res.id).exists()
+
+    assert resp2.status_code == 404
+


### PR DESCRIPTION
Title:
Add idempotent cancel reservation test

Description:
Covers case where a reservation is cancelled twice:

First DELETE returns 200 and removes the reservation

Second DELETE returns 404, since the reservation no longer exists

Run locally:

pytest reservations/tests/views/test_cancel_reservation_idempotent.py::test_cancel_reservation_twice_second_call_404 -v