### PR TITLE
tests(events): require authentication for event creation (401)

### DIFF
--- a/backend/events/tests/views/test_create_requires_auth.py
+++ b/backend/events/tests/views/test_create_requires_auth.py
@@ -1,0 +1,24 @@
+import pytest
+from rest_framework.test import APIClient
+from events.models import Event
+from django.utils import timezone
+from datetime import timedelta
+
+@pytest.mark.django_db
+def test_create_event_requires_auth_returns_401():
+    # Arrange
+    client = APIClient()
+    payload = {
+        "title": "Unauthorized Event",
+        "location": "Nowhere",
+        "start_time": (timezone.now() + timedelta(days=1)).isoformat(),
+        "end_time": (timezone.now() + timedelta(days=1, hours=2)).isoformat(),
+        "seats_limit": 10,
+    }
+
+    # Act
+    resp = client.post("/api/events/organizer/events/create/", payload, format="json")
+
+    # Assert
+    assert resp.status_code == 401
+    assert Event.objects.count() == 0


### PR DESCRIPTION
Title:
Event creation requires authentication (401)

Description:
Adds a test to ensure that creating an event without authentication:

Returns 401 Unauthorized

Does not create any Event in the database

Run locally:

pytest events/tests/views/test_create_requires_auth.py -v