### PR TITLE
chore: add .env.example with base variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+DJANGO_SECRET_KEY=change-me
+DEBUG=false
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+DATABASE_URL=sqlite:///db.sqlite3
+REDIS_URL=redis://localhost:6379/0
+
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=EventFlow <no-reply@example.com>
+
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+SENTRY_DSN=


### PR DESCRIPTION
Added backend/.env.example file with basic environment variables:
- SECRET_KEY, DEBUG, ALLOWED_HOSTS
- DATABASE_URL, REDIS_URL
- email configuration
- CORS_ALLOWED_ORIGINS
- SENTRY_DSN

Goal: to make it easier for others to launch the project and prepare it for CI/CD.