### PR TITLE
fix: mark public endpoints with AllowAny

### DIFF
--- a/backend/events/views/available_places_to_event.py
+++ b/backend/events/views/available_places_to_event.py
@@ -1,11 +1,14 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import status
+from rest_framework import status, permissions
 from events.models import Event
 from events.serializers.available_places_to_event import AvailablePlacesToEvent
 
 
 class EventAvailablePlacesView(APIView):
+
+    permission_classes = [permissions.AllowAny]  
+
 
     def get(self, request, event_id):
 

--- a/backend/events/views/event_list.py
+++ b/backend/events/views/event_list.py
@@ -1,8 +1,9 @@
-from rest_framework import generics
+from rest_framework import generics, permissions
 from django_filters.rest_framework import DjangoFilterBackend
 from events.models.event import Event
 from events.serializers.event_list import EventListSerializer
 from rest_framework.pagination import PageNumberPagination
+
 
 
 class EventListPagination(PageNumberPagination):
@@ -18,4 +19,4 @@ class EventListView(generics.ListAPIView):
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["start_time", "location", "organizer"]
     pagination_class = EventListPagination
-    permission_classes = []  
+    permission_classes = [permissions.AllowAny]  


### PR DESCRIPTION
- Added `permission_classes = [AllowAny]` to public endpoints:
  - EventListView (events list)
  - EventAvailablePlacesView (availability endpoint)

Reason: default permission is `IsAuthenticated`, public endpoints must remain accessible without login.
