### PR TITLE
feat(health): add /health endpoint with DB and Redis checks

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -22,6 +22,11 @@ from rest_framework_simplejwt.views import (
 )
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
+from django.http import JsonResponse
+from django.db import connection
+import redis
+import os
+
 
 
 # --- v1 package ---
@@ -37,6 +42,32 @@ api_v1_patterns = [
     path("redoc/", SpectacularRedocView.as_view(url_name="schema_v1"), name="redoc_v1"),
 ]
 
+def healthcheck(request):
+    db_ok = True
+    redis_ok = True
+
+    # DB check
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1;")
+            cursor.fetchone()
+    except Exception:
+        db_ok = False
+
+    # Redis check (opcjonalnie)
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        r = redis.Redis.from_url(redis_url)
+        r.ping()
+    except Exception:
+        redis_ok = False
+
+    status = 200 if (db_ok and redis_ok) else 503
+    return JsonResponse({"status": "ok" if status == 200 else "fail", "db": db_ok, "redis": redis_ok}, status=status)
+
+
+
+
 urlpatterns = [
     path("admin/", admin.site.urls),
 
@@ -50,6 +81,9 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
+
+
+    path("health/", healthcheck, name="health"),
 
 
     # --- oficjalne v1 ---


### PR DESCRIPTION
- Introduces /health endpoint for liveness/readiness checks.
- Verifies DB connection with a simple SELECT 1.
- Verifies Redis connectivity (optional, fallback if Redis not running).
- Returns JSON: {"status": "ok"/"fail", "db": bool, "redis": bool}.
- Useful for deployment probes and monitoring.