### PR TITLE
ci: add GitHub Actions (pytest + coverage + ruff/black/isort)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-test-lint:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          # Dev tools for CI (even if not in requirements.txt)
+          pip install pytest pytest-cov ruff==0.6.9 black==24.8.0 isort==5.13.2
+
+      - name: Ruff (lint)
+        run: ruff check .
+
+      - name: Black (format check)
+        run: black --check .
+
+      - name: isort (import order)
+        run: isort --check-only .
+
+      - name: Pytest (with coverage)
+        env:
+          # Minimal env so Django can boot in CI if needed
+          DJANGO_SECRET_KEY: "ci-key"
+          DEBUG: "False"
+          ALLOWED_HOSTS: "localhost,127.0.0.1"
+        run: |
+          pytest -q --cov=. --cov-report=xml
+
+      - name: Upload coverage.xml
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: backend/coverage.xml
+          if-no-files-found: warn


### PR DESCRIPTION
- Adds a CI workflow:
  - pytest with coverage (XML artifact)
  - ruff, black, isort checks
  - runs on PRs and main pushes
- Uses backend/ as working directory; installs dev tools explicitly.
- Prepares ground for coverage badges (Codecov can be added later).
