### PR TITLE
feat(docker): add initial Dockerfile for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+# backend/Dockerfile
+
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
### Changes
- Added `backend/Dockerfile` to containerize the Django backend.
- Image is based on python:3.11-slim with required system dependencies.
- Installs project dependencies from `requirements.txt`.
- Exposes port 8000 and starts the development server.

### Why
- This is the first step towards full Docker support (with compose, DB, Redis, etc.).
- Allows the backend to run inside a container, independent of the local environment.
