### PR TITLE
fix(settings): secure CORS configuration for production

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -73,7 +73,12 @@ MIDDLEWARE = [
 ]
 
 # CORS
-CORS_ALLOW_ALL_ORIGINS = True
+##############
+CSRF_TRUSTED_ORIGINS = [
+    o for o in os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",") if o
+]
+
+
 
 ROOT_URLCONF = "config.urls"
 


### PR DESCRIPTION
This PR improves the CORS configuration by removing the hardcoded 
`CORS_ALLOW_ALL_ORIGINS = True` that was always overriding settings.

- In development (DEBUG=True), allow-all is still enabled for convenience
- In production (DEBUG=False), only origins defined via environment 
  variables are allowed
- (Optional) Added support for CSRF_TRUSTED_ORIGINS for better security 
  when needed

This change prevents exposing the API to the entire internet in production 
environments while keeping local development simple.
