### PR TITLE
chore(settings): use console email backend in development

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -214,3 +214,7 @@ LOGGING = {
     },
     "root": {"handlers": ["console"], "level": "INFO"},
 }
+
+
+if DEBUG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
This PR configures Django to use the console email backend when DEBUG=True.

- Emails are no longer sent to external SMTP in development
- All outgoing emails (e.g. account activation) are displayed directly in logs
- Production environments remain unaffected and still rely on configured SMTP backend

This improves developer experience by avoiding external email dependencies while testing locally.
