### PR TITLE
docs(frontend): add .env.local.example and update .gitignore

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -30,8 +30,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files (ignored by default)
 .env*
+# but allow example envs
+!*.env*.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Added frontend/.env.local.example with NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

Updated frontend/.gitignore to ignore all .env* files except .example files

This ensures secrets stay out of git, while keeping a clear example for setup

How to test:

Copy .env.local.example → .env.local in the frontend/ folder

Run npm run dev (or docker compose up frontend)

Frontend should correctly use NEXT_PUBLIC_API_BASE_URL