### PR TITLE
feat(frontend): show toast on reservation cancel

### DIFF
--- a/frontend/src/app/my-reservations/page.tsx
+++ b/frontend/src/app/my-reservations/page.tsx
@@ -67,12 +67,18 @@ export default function MyReservationsPage() {
   </div>
 
   {/* pod spodem */}
+    {/* pod spodem */}
+    {/* pod spodem */}
+    {/* pod spodem */}
   <div style={{ marginTop: "8px" }}>
     <CancelReservationButton
       reservationId={res.reservation_id}
       onSuccess={fetchReservations}
     />
   </div>
+
+
+
 </li>
 
         ))}

--- a/frontend/src/components/buttons/reservations-buttons/CancelReservationButton.tsx
+++ b/frontend/src/components/buttons/reservations-buttons/CancelReservationButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { cancelReservation } from "@/lib/api/reservations";
+import { toast } from "react-hot-toast";
 
 interface CancelReservationButtonProps {
   reservationId: number;
@@ -12,28 +12,21 @@ export default function CancelReservationButton({
   reservationId,
   onSuccess,
 }: CancelReservationButtonProps) {
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
-
   const handleCancel = async () => {
-    const res = await cancelReservation(reservationId);
+    try {
+      const res = await cancelReservation(reservationId);
 
-    if (res.ok) {
-      setSuccess("Rezerwacja została anulowana.");
-      setError("");
-      onSuccess();
-    } else {
-      const data = await res.json().catch(() => ({}));
-      setError(data.detail || "Nie udało się anulować rezerwacji.");
-      setSuccess("");
+      if (res.ok) {
+        toast.success("Rezerwacja została anulowana.");
+        onSuccess();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.detail || "Nie udało się anulować rezerwacji.");
+      }
+    } catch (e: any) {
+      toast.error(e?.message || "Błąd połączenia z serwerem.");
     }
   };
 
-  return (
-    <>
-      <button onClick={handleCancel}>Anuluj rezerwację</button>
-      {success && <p style={{ color: "green" }}>{success}</p>}
-      {error && <p style={{ color: "red" }}>{error}</p>}
-    </>
-  );
+  return <button onClick={handleCancel}>Anuluj rezerwację</button>;
 }


### PR DESCRIPTION
Updated CancelReservationButton to use react-hot-toast for user feedback.

On successful cancellation, a green toast notification is displayed.

On error (e.g., permission denied, server issue), a red toast with the error message is shown.

Integrated the updated button in my-reservations/page.tsx.

Result: users now get immediate, consistent feedback in the UI instead of inline messages under the button.