### PR TITLE
feat(backend): add X-Request-ID middleware for request tracing

### DIFF
--- a/backend/config/middleware/request_id.py
+++ b/backend/config/middleware/request_id.py
@@ -1,0 +1,23 @@
+import uuid
+from django.utils.deprecation import MiddlewareMixin
+
+class RequestIDMiddleware(MiddlewareMixin):
+    """
+    Ustawia unikalny X-Request-ID na każdym żądaniu.
+    Jeśli klient dostarczył X-Request-ID, to go zachowujemy.
+    """
+    HEADER_NAME = "HTTP_X_REQUEST_ID"   # w request.META
+    RESPONSE_HEADER = "X-Request-ID"    # w odpowiedzi
+
+    def process_request(self, request):
+        rid = request.META.get(self.HEADER_NAME)
+        if not rid:
+            rid = str(uuid.uuid4())
+        request.request_id = rid
+        return None
+
+    def process_response(self, request, response):
+        rid = getattr(request, "request_id", None)
+        if rid:
+            response[self.RESPONSE_HEADER] = rid
+        return response

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "config.middleware.request_id.RequestIDMiddleware",
 ]
 
 # CORS


### PR DESCRIPTION
This pull request introduces a new middleware that automatically attaches a unique X-Request-ID header to every HTTP request and response.
It allows for improved observability, easier debugging, and correlation of backend logs with client requests.

 Changes

Added new middleware: RequestIDMiddleware (backend/config/middleware/request_id.py)

Integrated it into MIDDLEWARE settings in config/settings.py

Each request now includes an X-Request-ID (UUID v4) header, generated if not provided by the client.

 Testing

Start the backend.

Open /health endpoint in browser or Postman.

Check Response Headers — the value of X-Request-ID should appear (e.g., 4a192ee3-466b-4970-9647-775993a8302f).

 Impact

This improves traceability of API calls, particularly useful when combined with structured logging or centralized log management (e.g., ELK/Sentry).